### PR TITLE
(MAINT) Re-generalize package template

### DIFF
--- a/gather/gather.nuspec
+++ b/gather/gather.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>gather</id>
-    <version>0.0.9</version>
+    <version>[[VERSION]]</version>
     <title>gather</title>
     <authors>michaeltlombardi</authors>
     <projectUrl>https://gather.town/</projectUrl>
@@ -19,7 +19,7 @@
 Spend time with your friends, coworkers, and communities like you would in real life.
 
 Desktop application for [gather.town](https://gather.town), a virtual spaces service with video calling, interactive maps, games, and more.</description>
-    <releaseNotes>https://github.com/gathertown/gather-town-desktop-releases/releases/tag/v0.0.9</releaseNotes>
+    <releaseNotes>https://github.com/gathertown/gather-town-desktop-releases/releases/tag/v[[VERSION]]</releaseNotes>
   </metadata>
   <files>
     <!-- this section controls what actually gets packaged into the Chocolatey package -->

--- a/gather/tools/chocolateyinstall.ps1
+++ b/gather/tools/chocolateyinstall.ps1
@@ -1,5 +1,5 @@
 $ErrorActionPreference = 'Stop';
-$toolsDir     = "$(Split-Path -parent $MyInvocation.MyCommand.Definition)"
+$toolsDir = "$(Split-Path -Parent $MyInvocation.MyCommand.Definition)"
 
 $packageArgs = @{
   packageName    = $env:ChocolateyPackageName
@@ -8,8 +8,8 @@ $packageArgs = @{
   fileType       = 'exe'
   silentArgs     = '/S'
   validExitCodes = @(0)
-  url            = 'https://github.com/gathertown/gather-town-desktop-releases/releases/download/v0.0.9/Gather-Setup-0.0.9.exe'
-  checksum       = '498DFFC48FD3D53A1CC65C564C99627084DBC931B163FF203CD4FF1F482614EF'
+  url            = '[[URL]]'
+  checksum       = '[[CHECKSUM]]'
   checksumType   = 'sha256'
 }
 


### PR DESCRIPTION
Prior to this commit, the package template was committed with the version, download URL, and checksum filled out for `v0.0.9` instead of using the template values. This caused the script to always attempt to rerelease `0.0.9` instead of any newer version released.

This PR returns the values to their template settings to enable build and automation.