### PR TITLE
(GH-2) Add GHA workflow for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+on:
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  Test:
+    runs-on: windows-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package:
+          - gather
+    steps:
+      - uses: actions/checkout@v2
+      - name: PSVersion Table
+        run: $psversiontable
+      - name: Chocolatey Version
+        run: choco --version
+      - name: Validate ${{ matrix.package }} Build
+        run: |
+          & .\${{ matrix.package }}.ps1 -ValidateInstall -Verbose -ErrorAction Stop


### PR DESCRIPTION
The CI workflow runs once for each package (currently, only gather) and validates that the newest version can be found and built.